### PR TITLE
Add functions to initialize single cylindrical cell in fov center

### DIFF
--- a/src/cell_abm_pipeline/initial_conditions/README.md
+++ b/src/cell_abm_pipeline/initial_conditions/README.md
@@ -10,11 +10,12 @@ Options:
   --help              Show this message and exit.
 
 Commands:
-  convert-arcade   Convert samples into ARCADE input formats.
-  create-voronoi   Create Voronoi tessellation from given starting image.
-  download-images  Download images from Quilt package.
-  process-samples  Process samples with selected processing steps.
-  sample-images    Sample cell ids and coordinates from images.
+  convert-arcade        Convert samples into ARCADE input formats.
+  create-voronoi        Create Voronoi tessellation from given starting...
+  download-images       Download images from Quilt package.
+  generate-coordinates  Generate cell ids and coordinates.
+  process-samples       Process samples with selected processing steps.
+  sample-images         Sample cell ids and coordinates from images.
 ```
 
 All modules require a `Context` object that defines the working context.
@@ -35,6 +36,24 @@ Usage: initial-conditions download-images [OPTIONS]
 
 Options:
   -n, --num-images INTEGER  Number of images to download.  [default: 0]
+  --help                    Show this message and exit.
+```
+
+## Generate cell ids and coordinates
+
+The `GenerateCoordinates` module can be called via CLI using:
+
+```
+Usage: initial-conditions generate-coordinates [OPTIONS]
+
+  Generate cell ids and coordinates.
+
+Options:
+  -g, --grid [rect|hex]     Type of sampling grid.  [default: rect]
+  --ds FLOAT                Distance between elements in um.  [default: 1.0]
+  --box INTEGER...          Bounding box size in um.  [default: 100, 100, 10]
+  --contact / --no-contact  True if contact sheet of images is saved, False
+                            otherwise. [default: True]
   --help                    Show this message and exit.
 ```
 

--- a/src/cell_abm_pipeline/initial_conditions/__main__.py
+++ b/src/cell_abm_pipeline/initial_conditions/__main__.py
@@ -169,7 +169,7 @@ def sample_images(obj, **kwargs):
 @click.option(
     "--contact/--no-contact",
     default=True,
-    help="True if contact sheet of images is saved, False otherwise. [default: True]",
+    help="True if contact sheet of images is saved, False otherwise.  [default: True]",
 )
 @click.pass_obj
 def process_samples(obj, **kwargs):

--- a/src/cell_abm_pipeline/initial_conditions/__main__.py
+++ b/src/cell_abm_pipeline/initial_conditions/__main__.py
@@ -66,6 +66,43 @@ def download_images(obj, **kwargs):
     show_default=True,
 )
 @click.option(
+    "--ds",
+    type=float,
+    default=1.0,
+    help="Distance between elements in um.",
+    show_default=True,
+)
+@click.option(
+    "--box",
+    nargs=3,
+    type=int,
+    default=(100, 100, 10),
+    help="Bounding box size in um.",
+    show_default=True,
+)
+@click.option(
+    "--contact/--no-contact",
+    default=True,
+    help="True if contact sheet of images is saved, False otherwise. [default: True]",
+)
+@click.pass_obj
+def generate_coordinates(obj, **kwargs):
+    """Generate cell ids and coordinates."""
+    from .generate_coordinates import GenerateCoordinates
+
+    GenerateCoordinates(obj).run(**kwargs)
+
+
+@cli.command()
+@click.option(
+    "-g",
+    "--grid",
+    type=click.Choice(["rect", "hex"], case_sensitive=False),
+    default="rect",
+    help="Type of sampling grid.",
+    show_default=True,
+)
+@click.option(
     "-r",
     "--resolution",
     type=float,
@@ -132,7 +169,7 @@ def sample_images(obj, **kwargs):
 @click.option(
     "--contact/--no-contact",
     default=True,
-    help="True if contact sheet of images is saved, False otherwise.  [default: True]",
+    help="True if contact sheet of images is saved, False otherwise. [default: True]",
 )
 @click.pass_obj
 def process_samples(obj, **kwargs):

--- a/src/cell_abm_pipeline/initial_conditions/generate_coordinates.py
+++ b/src/cell_abm_pipeline/initial_conditions/generate_coordinates.py
@@ -1,0 +1,298 @@
+from math import floor, pi, sqrt, ceil
+from typing import Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+from hexalattice.hexalattice import create_hex_grid
+
+from cell_abm_pipeline.initial_conditions.__config__ import (
+    CRITICAL_VOLUME_AVGS,
+    CRITICAL_HEIGHT_AVGS,
+)
+from cell_abm_pipeline.initial_conditions.__main__ import Context
+from cell_abm_pipeline.utilities.load import load_dataframe
+from cell_abm_pipeline.utilities.save import save_dataframe, save_plot
+from cell_abm_pipeline.utilities.keys import make_folder_key, make_file_key, make_full_key
+from cell_abm_pipeline.utilities.plot import make_plot
+
+
+class GenerateCoordinates:
+    """
+    Task to generate cell ids and coordinates.
+
+    Working location structure for a given context:
+
+    .. code-block:: bash
+
+        (name)
+        ├── plots
+        │    └── plots.COORDINATES
+        │        ├── (name)_(image key 1).COORDINATES.png
+        │        ├── (name)_(image key 2).COORDINATES.png
+        │        ├── ...
+        │        └── (name)_(image key n).COORDINATES.png
+        └── inits
+            └── inits.COORDINATES
+                ├── (name)_(image key 1).COORDINATES.csv
+                ├── (name)_(image key 2).COORDINATES.csv
+                ├── ...
+                └── (name)_(image key n).COORDINATES.csv
+
+    Generated coordinates are placed into the **inits/inits.GENERATED** directory.
+    Corresponding plots are placed into the **plots/plots.GENERATED** directory.
+
+    Attributes
+    ----------
+    context
+        **Context** object defining working location and name.
+    folders
+        Dictionary of input and output folder keys.
+    files
+        Dictionary of input and output file keys.
+    """
+
+    def __init__(self, context: Context):
+        self.context = context
+        self.folders = {
+            "coordinates": make_folder_key(context.name, "inits", "COORDINATES", False),
+            "contact": make_folder_key(context.name, "plots", "COORDINATES", False),
+        }
+        self.files = {
+            "coordinates": make_file_key(context.name, ["COORDINATES", "csv"], "%s", ""),
+            "contact": make_file_key(context.name, ["COORDINATES", "png"], "%s", ""),
+        }
+
+    def run(
+        self,
+        grid: str = "rect",
+        ds: float = 1.0,
+        box: Tuple[int, int, int] = (100, 100, 10),
+        contact: bool = True,
+    ) -> None:
+        """
+        Runs generate coordinates task for given context.
+
+        Parameters
+        ----------
+        grid : {'rect', 'hex'}
+            Type of sampling grid.
+        ds
+            Distance between elements in um.
+        box
+            Bounding box size in um.
+        contact
+            True if contact sheet of coordinates is saved, False otherwise.
+        """
+        for key in self.context.keys:
+            self.generate_coordinates(key, grid, ds, box)
+
+            if contact:
+                self.plot_contact_sheet(key)
+
+    def generate_coordinates(
+        self, key: str, grid: str, ds: float, box: Tuple[int, int, int]
+    ) -> None:
+        # Calculate cell sizes (in um).
+        cell_height = CRITICAL_HEIGHT_AVGS["DEFAULT"] / ds
+        cell_volume = CRITICAL_VOLUME_AVGS["DEFAULT"]
+        cell_radius = sqrt(cell_volume / cell_height / pi) / ds
+        cell_bounds = (ceil(2 * cell_radius), ceil(2 * cell_radius), ceil(cell_height))
+
+        # Calculate cell center.
+        length, width, _ = [box_dim / ds for box_dim in box]
+        center = (length / 2, width / 2)
+
+        # Generate coordinates for cell around centroid.
+        coordinates = self.get_box_coordinates(cell_bounds, grid)
+        coordinates = self.transform_cell_coordinates(coordinates, cell_radius, center)
+
+        # Convert to dataframe and save.
+        coordinates_df = pd.DataFrame(coordinates, columns=["x", "y", "z"])
+        coordinates_df["id"] = 1
+        coordinates_key = make_full_key(self.folders, self.files, "coordinates", key)
+        save_dataframe(self.context.working, coordinates_key, coordinates_df, index=False)
+
+    def plot_contact_sheet(self, key: str) -> None:
+        """
+        Plot contact sheet for generated coordinates.
+
+        Parameters
+        ----------
+        key
+            Key for coordinates.
+        """
+        coordinates_key = make_full_key(self.folders, self.files, "coordinates", key)
+        data = load_dataframe(self.context.working, coordinates_key)
+
+        make_plot(sorted(data.z.unique()), data, self.plot_contact_sheet_axes)
+
+        plt.gca().invert_yaxis()
+        plot_key = make_full_key(self.folders, self.files, "contact", key)
+        save_plot(self.context.working, plot_key)
+
+    @staticmethod
+    def plot_contact_sheet_axes(ax: Axes, data: pd.DataFrame, key: int) -> None:
+        """
+        Plot coordinates for selected z index, colored by id.
+
+        Parameters
+        ----------
+        ax
+            **Axes** instance to plot on.
+        data
+            Coordinates data.
+        key
+            Index of z slice to plot.
+        """
+        z_slice = data[data.z == key]
+
+        max_id = int(data.id.max())
+        min_id = int(data.id.min())
+
+        ax.scatter(z_slice.x, z_slice.y, c=z_slice.id, vmin=min_id, vmax=max_id, s=1, cmap="jet")
+        ax.set_aspect("equal", adjustable="box")
+
+    @staticmethod
+    def get_box_coordinates(
+        bounds: Tuple[int, int, int],
+        grid: str = "rect",
+    ) -> List:
+        """
+        Get all possible coordinates within given bounding box.
+
+        Parameters
+        ----------
+        bounds
+            Bounds in the x, y, and z directions.
+        grid : {'rect', 'hex'}
+            Type of sampling grid.
+
+        Returns
+        -------
+        :
+            List of grid coordinates.
+        """
+        if grid == "rect":
+            return GenerateCoordinates.make_rect_coordinates(bounds, 1, 1)
+
+        if grid == "hex":
+            return GenerateCoordinates.make_hex_coordinates(bounds, 1, 1)
+
+        raise ValueError(f"invalid grid type {grid}")
+
+    @staticmethod
+    def make_rect_coordinates(
+        bounds: Tuple[int, int, int],
+        xy_increment: float,
+        z_increment: float,
+    ) -> List:
+        """
+        Get list of bounded (x, y, z) coordinates for rect grid.
+
+        Parameters
+        ----------
+        bounds
+            Bounds in the x, y, and z directions.
+        xy_increment
+            Increment size in x/y.
+        z_increment
+            Increment size in z.
+
+        Returns
+        -------
+        :
+            List of grid coordinates.
+        """
+        x_bound, y_bound, z_bound = bounds
+
+        z_indices = np.arange(0, z_bound, z_increment)
+        x_indices = np.arange(0, x_bound, xy_increment)
+        y_indices = np.arange(0, y_bound, xy_increment)
+
+        coordinates = [(x, y, z) for z in z_indices for x in x_indices for y in y_indices]
+
+        return coordinates
+
+    @staticmethod
+    def make_hex_coordinates(
+        bounds: Tuple[int, int, int],
+        xy_increment: float,
+        z_increment: float,
+    ) -> List:
+        """
+        Get list of bounded (x, y, z) coordinates for hex grid.
+
+        Coordinates are offset in sets of three z slices to form a face-centered
+        cubic (FCC) packing.
+
+        Parameters
+        ----------
+        bounds
+            Bounds in the x, y, and z directions.
+        xy_increment
+            Increment size in x/y.
+        z_increment
+            Increment size in z.
+
+        Returns
+        -------
+        :
+            List of grid coordinates.
+        """
+        x_bound, y_bound, z_bound = bounds
+
+        z_indices = np.arange(0, z_bound, z_increment)
+        z_offsets = [(i % 3) for i in range(len(z_indices))]
+
+        xy_indices, _ = create_hex_grid(
+            nx=floor(x_bound / xy_increment),
+            ny=floor(y_bound / xy_increment * sqrt(3)),
+            min_diam=xy_increment,
+            align_to_origin=False,
+            do_plot=False,
+        )
+
+        x_offsets = [(xy_increment / 2) if z_offset == 1 else 0 for z_offset in z_offsets]
+        y_offsets = [(xy_increment / 2) * sqrt(3) / 3 * z_offset for z_offset in z_offsets]
+
+        coordinates = [
+            (x + x_offset, y + y_offset, z)
+            for z, x_offset, y_offset in zip(z_indices, x_offsets, y_offsets)
+            for x, y in xy_indices
+            if round(x + x_offset) < x_bound and round(y + y_offset) < y_bound
+        ]
+
+        return coordinates
+
+    @staticmethod
+    def transform_cell_coordinates(
+        coordinates: List, radius: float, offsets: Tuple[float, float]
+    ) -> List:
+        """
+        Filters list for coordinates with given radius and applies offset.
+
+        Parameters
+        ----------
+        coordinates
+            List of (x, y, z) coordinates.
+        radius
+            Maximum valid radius of coordinate.
+        offsets
+            Coordinate offsets in the x and y directions.
+
+        Returns
+        -------
+        :
+            Filtered list of coordinates.
+        """
+        dx, dy = offsets
+        filtered_coordinates = []
+
+        for x, y, z in coordinates:
+            coordinate_radius = (x - radius) ** 2 + (y - radius) ** 2
+            if coordinate_radius <= radius**2:
+                filtered_coordinates.append((x - radius + dx, y - radius + dy, z))
+
+        return filtered_coordinates

--- a/src/cell_abm_pipeline/initial_conditions/generate_coordinates.py
+++ b/src/cell_abm_pipeline/initial_conditions/generate_coordinates.py
@@ -1,5 +1,5 @@
 from math import floor, pi, sqrt, ceil
-from typing import Dict, List, Tuple
+from typing import List, Tuple
 
 import numpy as np
 import pandas as pd
@@ -94,6 +94,23 @@ class GenerateCoordinates:
     def generate_coordinates(
         self, key: str, grid: str, ds: float, box: Tuple[int, int, int]
     ) -> None:
+        """
+        Generate coordinates task.
+
+        Calculates and generates coordinates inside bounding box, then filters
+        out coordinates outside the target radius.
+
+        Parameters
+        ----------
+        key
+            Key for output coordinates.
+        grid : {'rect', 'hex'}
+            Type of coordinate grid.
+        ds
+            Distance between elements in um.
+        box
+            Bounding box size in um.
+        """
         # Calculate cell sizes (in um).
         cell_height = CRITICAL_HEIGHT_AVGS["DEFAULT"] / ds
         cell_volume = CRITICAL_VOLUME_AVGS["DEFAULT"]
@@ -287,12 +304,13 @@ class GenerateCoordinates:
         :
             Filtered list of coordinates.
         """
-        dx, dy = offsets
+        x_offset, y_offset = offsets
         filtered_coordinates = []
+        x_center, y_center, _ = np.array(coordinates).mean(axis=0)
 
         for x, y, z in coordinates:
-            coordinate_radius = (x - radius) ** 2 + (y - radius) ** 2
+            coordinate_radius = (x - x_center) ** 2 + (y - y_center) ** 2
             if coordinate_radius <= radius**2:
-                filtered_coordinates.append((x - radius + dx, y - radius + dy, z))
+                filtered_coordinates.append((x - x_center + x_offset, y - y_center + y_offset, z))
 
         return filtered_coordinates

--- a/src/cell_abm_pipeline/initial_conditions/sample_images.py
+++ b/src/cell_abm_pipeline/initial_conditions/sample_images.py
@@ -46,7 +46,7 @@ class SampleImages:
 
     The **images** directory contains the input images to be sampled.
     Resulting samples are placed into the **samples/samples.RAW** directory and
-    corresponding plots are placed into the **`plots/plots.SAMPLE** directory.
+    corresponding plots are placed into the **plots/plots.SAMPLE** directory.
 
     Attributes
     ----------
@@ -346,95 +346,3 @@ class SampleImages:
         array = image.get_image_data("XYZ", T=0, C=channel)
         samples = [(array[x, y, z], x, y, z) for x, y, z in sample_indices if array[x, y, z] > 0]
         return samples
-
-    @staticmethod
-    def crop_sample_grid_to_cylinder(
-        sample_indices: List, cell_radius: float, fov_xysize: Tuple[int, int]
-        ) -> List:
-        """
-        Converts a 3D rectangle of sampled points into the initial conditions
-        for a single cell by cropping the rectangle of sampled points to a 
-        cylinder and offsetting that "cell" to the center of an FOV frame
-        ofa given size 
-
-        Parameters
-        ----------
-        sample_indices
-            List of sampling indices.
-        cell_radius
-            Radius of single cell to initialize
-        fov_xysize
-            Size of 2D (xy) slices of FOVs
-
-        Returns
-        -------
-        :
-            List of image samples corresponding to a single cell
-            in the center of a field of view
-        """
-
-        # Get 3D offset to place cell at xy-center and z bottom
-        fov_offset = (fov_xysize[0]/2 - cell_radius, fov_xysize[1]/2 - cell_radius, 0)
-
-        # List of cell indices within fov to fill
-        cell_indices = []
-
-        # Center of cell before offsetting into FOV center
-        center = [cell_radius, cell_radius]
-
-        for sample_index in sample_indices:
-            if (center[0] - sample_index[0])**2 + (center[1] - sample_index[1])**2 <= cell_radius**2:
-                cell_index = tuple(map(operator.add, sample_index, fov_offset))
-                cell_indices.append(cell_index)
-        return cell_indices
-
-    @staticmethod
-    def get_single_cell_init(
-            cell_radius: float, cell_height: float, resolution: float,
-            scale_xy: float, scale_z: 1, fov_xysize: Tuple[int, int]
-            ) -> List:
-        """
-        Generates agent positions to initialize a single cylindrical cell at
-        the center of an FOV. First, we create a 3D rectangle of points
-        sampled in a hexagonal grid (whose size is equal to the desired
-        cell radius in x and y and the desired cell height in z). Then we
-        get the initial conditions for a single cylindrical cell by cropping
-        the rectangle of sampled points to a cylinder and offsetting that
-        "cell" to the center (in xy) and bottom (in z) of an FOV frame of
-        a given size
-
-        Parameters
-        ----------
-        cell_radius
-            Radius of single cell to initialize
-        cell_radius
-            Height of single cell to initialize
-        resolution
-            Distance between samples (um)
-        scale_xy
-            Resolution scaling in x/y
-        scale_z
-            Resolution scaling in z
-        fov_xysize
-            Size of 2D (xy) slices of FOVs
-
-        Returns
-        -------
-        :
-            List of image samples corresponding to a single cylindrical cell
-            in the center of a field of view
-        """
-
-        # Get a 3D rectangular grid of hexagonally sampled points
-        sample_indices = SampleImages.get_hex_sample_indices(
-            (2*cell_radius, 2*cell_radius, cell_height),
-            resolution, scale_xy, scale_z
-        )
-
-        # filter to those falling within a cylindrical sample and
-        # offest to fov center
-        cell_indices = SampleImages.crop_sample_grid_to_cylinder(
-            sample_indices, cell_radius, fov_xysize
-        )
-
-        return cell_indices

--- a/src/cell_abm_pipeline/initial_conditions/sample_images.py
+++ b/src/cell_abm_pipeline/initial_conditions/sample_images.py
@@ -373,7 +373,7 @@ class SampleImages:
             in the center of a field of view
         """
 
-        # Get 3D offset for cell within FOV to place cell at xy-center and z bottom
+        # Get 3D offset to place cell at xy-center and z bottom
         fov_offset = (fov_xysize[0]/2 - cell_radius, fov_xysize[1]/2 - cell_radius, 0)
 
         # List of cell indices within fov to fill
@@ -387,9 +387,12 @@ class SampleImages:
                 cell_index = tuple(map(operator.add, sample_index, fov_offset))
                 cell_indices.append(cell_index)
         return cell_indices
-    
+
     @staticmethod
-    def get_single_cell_init(cell_radius: float, cell_height: float, resolution: float, scale_xy: float, scale_z: 1, fov_xysize: Tuple([int, int])) -> List:
+    def get_single_cell_init(
+            cell_radius: float, cell_height: float, resolution: float,
+            scale_xy: float, scale_z: 1, fov_xysize: Tuple([int, int])
+            ) -> List:
         """
         Generates agent positions to initialize a single cylindrical cell at
         the center of an FOV. First, we create a 3D rectangle of points
@@ -397,7 +400,8 @@ class SampleImages:
         cell radius in x and y and the desired cell height in z). Then we
         get the initial conditions for a single cylindrical cell by cropping
         the rectangle of sampled points to a cylinder and offsetting that
-        "cell" to the center (in xy) and bottom (in z) of an FOV frame of a given size 
+        "cell" to the center (in xy) and bottom (in z) of an FOV frame of
+        a given size
 
         Parameters
         ----------
@@ -423,14 +427,14 @@ class SampleImages:
 
         # Get a 3D rectangular grid of hexagonally sampled points
         sample_indices = SampleImages.get_hex_sample_indices(
-            (2*cell_radius, 2*cell_radius, cell_height), resolution, scale_xy, scale_z
+            (2*cell_radius, 2*cell_radius, cell_height),
+            resolution, scale_xy, scale_z
         )
 
-        # filter to those falling within a cylindrical sample and offest to fov center
+        # filter to those falling within a cylindrical sample and
+        # offest to fov center
         cell_indices = SampleImages.crop_sample_grid_to_cylinder(
             sample_indices, cell_radius, cell_height, fov_xysize
         )
 
         return cell_indices
-
-

--- a/src/cell_abm_pipeline/initial_conditions/sample_images.py
+++ b/src/cell_abm_pipeline/initial_conditions/sample_images.py
@@ -391,7 +391,7 @@ class SampleImages:
     @staticmethod
     def get_single_cell_init(
             cell_radius: float, cell_height: float, resolution: float,
-            scale_xy: float, scale_z: 1, fov_xysize: Tuple([int, int])
+            scale_xy: float, scale_z: 1, fov_xysize: Tuple[int, int]
             ) -> List:
         """
         Generates agent positions to initialize a single cylindrical cell at

--- a/src/cell_abm_pipeline/initial_conditions/sample_images.py
+++ b/src/cell_abm_pipeline/initial_conditions/sample_images.py
@@ -434,7 +434,7 @@ class SampleImages:
         # filter to those falling within a cylindrical sample and
         # offest to fov center
         cell_indices = SampleImages.crop_sample_grid_to_cylinder(
-            sample_indices, cell_radius, cell_height, fov_xysize
+            sample_indices, cell_radius, fov_xysize
         )
 
         return cell_indices

--- a/tests/cell_abm_pipeline/initial_conditions/test_generate_coordinates.py
+++ b/tests/cell_abm_pipeline/initial_conditions/test_generate_coordinates.py
@@ -1,0 +1,121 @@
+import unittest
+from math import sqrt
+
+from cell_abm_pipeline.initial_conditions.generate_coordinates import GenerateCoordinates
+
+
+class TestGenerateCoordinates(unittest.TestCase):
+    def test_get_box_coordinates_rect_grid(self):
+        bounds = (4, 6, 5)
+        expected_coordinates = [(x, y, z) for x in range(4) for y in range(6) for z in range(5)]
+
+        coordinates = GenerateCoordinates.get_box_coordinates(bounds, "rect")
+
+        self.assertSetEqual(set(expected_coordinates), set(coordinates))
+
+    def test_get_box_coordinates_hex_grid(self):
+        bounds = (2, 3, 4)
+        delta = sqrt(3)
+
+        base_hex_indices = [
+            (0, 0),
+            (1, 0),
+            (0.5, 0.5 * delta),
+            (1.5, 0.5 * delta),
+            (0, delta),
+            (1, delta),
+            (0.5, 1.5 * delta),
+            (1.5, 1.5 * delta),
+            (0, 2 * delta),
+            (1, 2 * delta),
+        ]
+        all_hex_indices = [
+            [(x, y, 0) for x, y in base_hex_indices],
+            [(x + 0.5, y + 0.5 * delta / 3, 1) for x, y in base_hex_indices],
+            [(x, y + delta / 3, 2) for x, y in base_hex_indices],
+            [(x, y, 3) for x, y in base_hex_indices],
+        ]
+        expected_coordinates = [
+            (x, y, z)
+            for hex_indices in all_hex_indices
+            for x, y, z in hex_indices
+            if round(x) < 2 and round(y) < 3
+        ]
+
+        coordinates = GenerateCoordinates.get_box_coordinates(bounds, "hex")
+
+        self.assertSetEqual(set(expected_coordinates), set(coordinates))
+
+    def test_get_box_coordinates_invalid_grid_throws_exception(self):
+        with self.assertRaises(ValueError):
+            bounds = (0, 0, 0)
+            grid = "invalid_grid"
+            GenerateCoordinates.get_box_coordinates(bounds, grid)
+
+    def test_make_rect_coordinates(self):
+        bounds = (4, 6, 5)
+        xy_increment = 2
+        z_increment = 4
+
+        expected_coordinates = [(x, y, z) for x in [0, 2] for y in [0, 2, 4] for z in [0, 4]]
+
+        coordinates = GenerateCoordinates.make_rect_coordinates(bounds, xy_increment, z_increment)
+
+        self.assertSetEqual(set(expected_coordinates), set(coordinates))
+
+    def test_make_hex_coordinates(self):
+        bounds = (4, 6, 13)
+        xy_increment = 2
+        z_increment = 4
+        delta = sqrt(3)
+
+        base_hex_indices = [
+            (0, 0),
+            (2, 0),
+            (1, delta),
+            (3, delta),
+            (0, 2 * delta),
+            (2, 2 * delta),
+            (1, 3 * delta),
+            (3, 3 * delta),
+        ]
+        all_hex_indices = [
+            [(x, y, 0) for x, y in base_hex_indices],
+            [(x + 1, y + delta / 3, 4) for x, y in base_hex_indices],
+            [(x, y + 2 * delta / 3, 8) for x, y in base_hex_indices],
+            [(x, y, 12) for x, y in base_hex_indices],
+        ]
+        expected_coordinates = [
+            (x, y, z)
+            for hex_indices in all_hex_indices
+            for x, y, z in hex_indices
+            if round(x) < 4 and round(y) < 6
+        ]
+
+        coordinates = GenerateCoordinates.make_hex_coordinates(bounds, xy_increment, z_increment)
+
+        self.assertSetEqual(set(expected_coordinates), set(coordinates))
+
+    def test_transform_cell_coordinates(self):
+        coordinates = [(x, y, z) for x in range(5, 8) for y in range(2, 5) for z in range(2, 4)]
+        radius = 1
+        x_offset, y_offset = (10, 20)
+
+        xy_coordinates = [
+            (-1 + x_offset, 0 + y_offset),
+            (0 + x_offset, -1 + y_offset),
+            (0 + x_offset, 0 + y_offset),
+            (0 + x_offset, 1 + y_offset),
+            (1 + x_offset, 0 + y_offset),
+        ]
+        expected_coordinates = [(x, y, z) for x, y in xy_coordinates for z in range(2, 4)]
+
+        coordinates = GenerateCoordinates.transform_cell_coordinates(
+            coordinates, radius, (x_offset, y_offset)
+        )
+
+        self.assertSetEqual(set(expected_coordinates), set(coordinates))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR expands on the class used to sample images to generate initial agent positions for a single cylindrical cell, sampled using the existing hexagonal grid sampling functionality.

The existing and unchanged `get_hex_sample_indices` method creates a 3D rectangular lattice of sampled positions on a hexagonal grid.
This PR adds a function which uses `get_hex_sample_indices` to create a hexagonally sampled rectangular grid size the desired cell radius in the x and y directions, and desired cell height in the z direction. It then crops this box to a cylinder of sampled positions, and offsets that cylinder to the (xy) center of an FOV of a given size.