### PR TITLE
Update create voronoi task with height clamping

### DIFF
--- a/src/cell_abm_pipeline/initial_conditions/README.md
+++ b/src/cell_abm_pipeline/initial_conditions/README.md
@@ -11,7 +11,7 @@ Options:
 
 Commands:
   convert-arcade   Convert samples into ARCADE input formats.
-  create-voronoi   Create Voronoi tessellation from given starting image.
+  create-voronoi   Create Voronoi tessellation from starting image.
   download-images  Download images from Quilt package.
   process-samples  Process samples with selected processing steps.
   sample-images    Sample cell ids and coordinates from images.
@@ -70,9 +70,9 @@ Options:
   --scale FLOAT                 Coordinate scaling factor.
   --select INTEGER              Specific cell ids to select.
   --edges / --no-edges          True if cells touching edges are removed,
-                                False otherwise. [default: False]
+                                False otherwise.  [default: False]
   --connected / --no-connected  True if unconnected voxels are removed, False
-                                otherwise. [default: False]
+                                otherwise.  [default: False]
   --contact / --no-contact      True if contact sheet of images is saved,
                                 False otherwise.  [default: True]
   --help                        Show this message and exit.
@@ -85,7 +85,7 @@ The `CreateVoronoi` module can be called via CLI using:
 ```
 Usage: initial-conditions create-voronoi [OPTIONS]
 
-  Create Voronoi tessellation from given starting image.
+  Create Voronoi tessellation from starting image.
 
 Options:
   -i, --iterations INTEGER  Number of boundary estimation steps.  [default: 2]

--- a/src/cell_abm_pipeline/initial_conditions/README.md
+++ b/src/cell_abm_pipeline/initial_conditions/README.md
@@ -10,11 +10,12 @@ Options:
   --help              Show this message and exit.
 
 Commands:
-  convert-arcade   Convert samples into ARCADE input formats.
-  create-voronoi   Create Voronoi tessellation from starting image.
-  download-images  Download images from Quilt package.
-  process-samples  Process samples with selected processing steps.
-  sample-images    Sample cell ids and coordinates from images.
+  convert-arcade        Convert samples into ARCADE input formats.
+  create-voronoi        Create Voronoi tessellation from given starting...
+  download-images       Download images from Quilt package.
+  generate-coordinates  Generate cell ids and coordinates.
+  process-samples       Process samples with selected processing steps.
+  sample-images         Sample cell ids and coordinates from images.
 ```
 
 All modules require a `Context` object that defines the working context.

--- a/src/cell_abm_pipeline/initial_conditions/README.md
+++ b/src/cell_abm_pipeline/initial_conditions/README.md
@@ -88,8 +88,9 @@ Usage: initial-conditions create-voronoi [OPTIONS]
   Create Voronoi tessellation from given starting image.
 
 Options:
-  -i, --iterations INTEGER  Number of boundary estimation steps  [default: 10]
+  -i, --iterations INTEGER  Number of boundary estimation steps.  [default: 2]
   -c, --channels INTEGER    Image channel indices.  [default: 0]
+  -h, --height INTEGER      Target height for tesselation.  [default: 10]
   --help                    Show this message and exit.
 ```
 

--- a/src/cell_abm_pipeline/initial_conditions/__main__.py
+++ b/src/cell_abm_pipeline/initial_conditions/__main__.py
@@ -147,7 +147,7 @@ def process_samples(obj, **kwargs):
     "-i",
     "--iterations",
     type=int,
-    default=10,
+    default=2,
     help="Number of boundary estimation steps.",
     show_default=True,
 )
@@ -158,6 +158,14 @@ def process_samples(obj, **kwargs):
     multiple=True,
     default=[0],
     help="Image channel indices.",
+    show_default=True,
+)
+@click.option(
+    "-h",
+    "--height",
+    type=int,
+    default=10,
+    help="Target height for tesselation.",
     show_default=True,
 )
 @click.pass_obj

--- a/src/cell_abm_pipeline/initial_conditions/__main__.py
+++ b/src/cell_abm_pipeline/initial_conditions/__main__.py
@@ -122,12 +122,12 @@ def sample_images(obj, **kwargs):
 @click.option(
     "--edges/--no-edges",
     default=False,
-    help="True if cells touching edges are removed, False otherwise. [default: False]",
+    help="True if cells touching edges are removed, False otherwise.  [default: False]",
 )
 @click.option(
     "--connected/--no-connected",
     default=False,
-    help="True if unconnected voxels are removed, False otherwise. [default: False]",
+    help="True if unconnected voxels are removed, False otherwise.  [default: False]",
 )
 @click.option(
     "--contact/--no-contact",
@@ -170,7 +170,7 @@ def process_samples(obj, **kwargs):
 )
 @click.pass_obj
 def create_voronoi(obj, **kwargs):
-    """Create Voronoi tessellation from given starting image."""
+    """Create Voronoi tessellation from starting image."""
     from .create_voronoi import CreateVoronoi
 
     CreateVoronoi(obj).run(**kwargs)

--- a/src/cell_abm_pipeline/initial_conditions/create_voronoi.py
+++ b/src/cell_abm_pipeline/initial_conditions/create_voronoi.py
@@ -12,7 +12,7 @@ from cell_abm_pipeline.utilities.keys import make_folder_key, make_file_key, mak
 
 class CreateVoronoi:
     """
-    Task to create Voronoi tessellation from given starting image.
+    Task to create Voronoi tessellation from starting image.
 
     Working location structure for a given context:
 

--- a/src/cell_abm_pipeline/initial_conditions/create_voronoi.py
+++ b/src/cell_abm_pipeline/initial_conditions/create_voronoi.py
@@ -53,7 +53,9 @@ class CreateVoronoi:
             "output": make_file_key(context.name, ["ome", "tiff"], "%s", "%02d_voronoi"),
         }
 
-    def run(self, iterations: int = 10, channels: Optional[List[int]] = None) -> None:
+    def run(
+        self, iterations: int = 2, channels: Optional[List[int]] = None, height: int = 10
+    ) -> None:
         """
         Runs create voronoi task for given context.
 
@@ -63,21 +65,24 @@ class CreateVoronoi:
             Number of boundary estimation steps.
         channels
             Image channel indices.
+        height
+            Target height for tesselation.
         """
         if channels is None:
             channels = [0]
 
         for key in self.context.keys:
             for channel in channels:
-                self.create_voronoi(key, iterations, channel)
+                self.create_voronoi(key, iterations, channel, height)
 
-    def create_voronoi(self, key: str, iterations: int, channel: int) -> None:
+    def create_voronoi(self, key: str, iterations: int, channel: int, height: int) -> None:
         """
         Create Voronoi task.
 
         Loads image from working location.
-        Creates boundary for Voronoi using binary dilation, then performs
-        the Voronoi tessellation using the selected channel of the image.
+        Creates boundary for Voronoi using binary dilation, clamped to the
+        target height, then performs the Voronoi tessellation using the selected
+        channel of the image.
 
         Parameters
         ----------
@@ -87,6 +92,8 @@ class CreateVoronoi:
             Number of boundary estimation steps.
         channel
             Image channel index.
+        height
+            Target height for tesselation.
         """
         image_key = make_full_key(self.folders, self.files, "image", key)
         image = load_image(self.context.working, image_key)

--- a/src/cell_abm_pipeline/initial_conditions/create_voronoi.py
+++ b/src/cell_abm_pipeline/initial_conditions/create_voronoi.py
@@ -51,7 +51,7 @@ class CreateVoronoi:
         }
         self.files = {
             "image": make_file_key(context.name, ["ome", "tiff"], "%s", ""),
-            "output": make_file_key(context.name, ["ome", "tiff"], "%s", "%02d_voronoi"),
+            "output": make_file_key(context.name, ["tiff"], "%s", "%02d_voronoi"),
         }
 
     def run(

--- a/tests/cell_abm_pipeline/initial_conditions/test_create_voronoi.py
+++ b/tests/cell_abm_pipeline/initial_conditions/test_create_voronoi.py
@@ -6,7 +6,7 @@ from cell_abm_pipeline.initial_conditions.create_voronoi import CreateVoronoi
 
 
 class TestCreateVoronoi(unittest.TestCase):
-    def test_get_bounded_array_without_holes(self):
+    def test_create_boundary_mask_without_holes(self):
         array = np.array(
             [
                 [
@@ -62,7 +62,7 @@ class TestCreateVoronoi(unittest.TestCase):
         mask = CreateVoronoi.create_boundary_mask(array, iterations=2)
         self.assertTrue(np.array_equal(expected_mask, mask))
 
-    def test_get_bounded_array_with_holes(self):
+    def test_create_boundary_mask_with_holes(self):
         array = np.array(
             [
                 [
@@ -104,7 +104,7 @@ class TestCreateVoronoi(unittest.TestCase):
         mask = CreateVoronoi.create_boundary_mask(array, iterations=2)
         self.assertTrue(np.array_equal(expected_mask, mask))
 
-    def test_get_array_slices_within_shape(self):
+    def test_get_array_slices_bounds_within_shape(self):
         array = np.zeros((11, 11, 11))
         array[2, 5, 5] = 1
         array[7, 5, 5] = 1
@@ -117,7 +117,7 @@ class TestCreateVoronoi(unittest.TestCase):
         slices = CreateVoronoi.get_array_slices(array)
         self.assertTupleEqual(expected_slices, slices)
 
-    def test_get_array_bounds_outside_shape(self):
+    def test_get_array_slices_bounds_outside_shape(self):
         array = np.zeros((3, 5, 7))
         array[0, 2, 3] = 1
         array[2, 2, 3] = 1

--- a/tests/cell_abm_pipeline/initial_conditions/test_create_voronoi.py
+++ b/tests/cell_abm_pipeline/initial_conditions/test_create_voronoi.py
@@ -108,7 +108,7 @@ class TestCreateVoronoi(unittest.TestCase):
         lower_bound = 7
         upper_bound = 11
         array = np.zeros((20, 1, 1))
-        array[lower_bound:upper_bound + 1,:,:] = 1
+        array[lower_bound : upper_bound + 1, :, :] = 1
         target_height = upper_bound - lower_bound + 1
 
         expected_bounds = (lower_bound, upper_bound + 1)
@@ -119,7 +119,7 @@ class TestCreateVoronoi(unittest.TestCase):
         lower_bound = 7
         upper_bound = 11
         array = np.zeros((20, 1, 1))
-        array[lower_bound:upper_bound + 1,:,:] = 1
+        array[lower_bound : upper_bound + 1, :, :] = 1
         target_height = upper_bound - lower_bound + 4
 
         expected_bounds = (lower_bound - 1, upper_bound + 3)

--- a/tests/cell_abm_pipeline/initial_conditions/test_create_voronoi.py
+++ b/tests/cell_abm_pipeline/initial_conditions/test_create_voronoi.py
@@ -104,6 +104,28 @@ class TestCreateVoronoi(unittest.TestCase):
         mask = CreateVoronoi.create_boundary_mask(array, iterations=2)
         self.assertTrue(np.array_equal(expected_mask, mask))
 
+    def test_adjust_mask_bounds_below_current_height(self):
+        lower_bound = 7
+        upper_bound = 11
+        array = np.zeros((20, 1, 1))
+        array[lower_bound:upper_bound + 1,:,:] = 1
+        target_height = upper_bound - lower_bound + 1
+
+        expected_bounds = (lower_bound, upper_bound + 1)
+        updated_bounds = CreateVoronoi.adjust_mask_bounds(array, target_height)
+        self.assertTupleEqual(expected_bounds, updated_bounds)
+
+    def test_adjust_mask_bounds_above_current_height(self):
+        lower_bound = 7
+        upper_bound = 11
+        array = np.zeros((20, 1, 1))
+        array[lower_bound:upper_bound + 1,:,:] = 1
+        target_height = upper_bound - lower_bound + 4
+
+        expected_bounds = (lower_bound - 1, upper_bound + 3)
+        updated_bounds = CreateVoronoi.adjust_mask_bounds(array, target_height)
+        self.assertTupleEqual(expected_bounds, updated_bounds)
+
     def test_get_array_slices_bounds_within_shape(self):
         array = np.zeros((11, 11, 11))
         array[2, 5, 5] = 1


### PR DESCRIPTION
The previous version of the `CreateVoronoi` task would estimate the Voronoi tessellation in all dimensions, leading to "tall" cells that fill the image z dimension. This PR implements a `--height` option for specifying the target height of the tessellation, centered around (and no smaller than) the current height of the Voronoi tessellation seeds.