### PR TITLE
Add exclude cell id option to process samples

### DIFF
--- a/src/cell_abm_pipeline/initial_conditions/README.md
+++ b/src/cell_abm_pipeline/initial_conditions/README.md
@@ -11,7 +11,7 @@ Options:
 
 Commands:
   convert-arcade        Convert samples into ARCADE input formats.
-  create-voronoi        Create Voronoi tessellation from given starting...
+  create-voronoi        Create Voronoi tessellation from starting image.
   download-images       Download images from Quilt package.
   generate-coordinates  Generate cell ids and coordinates.
   process-samples       Process samples with selected processing steps.
@@ -87,7 +87,7 @@ Usage: initial-conditions process-samples [OPTIONS]
 Options:
   -g, --grid [rect|hex]         Type of sampling grid.  [default: rect]
   --scale FLOAT                 Coordinate scaling factor.
-  --select INTEGER              Specific cell ids to select.
+  --include INTEGER             Specific cell ids to include.
   --edges / --no-edges          True if cells touching edges are removed,
                                 False otherwise.  [default: False]
   --connected / --no-connected  True if unconnected voxels are removed, False

--- a/src/cell_abm_pipeline/initial_conditions/README.md
+++ b/src/cell_abm_pipeline/initial_conditions/README.md
@@ -88,6 +88,7 @@ Options:
   -g, --grid [rect|hex]         Type of sampling grid.  [default: rect]
   --scale FLOAT                 Coordinate scaling factor.
   --include INTEGER             Specific cell ids to include.
+  --exclude INTEGER             Specific cell ids to exclude.
   --edges / --no-edges          True if cells touching edges are removed,
                                 False otherwise.  [default: False]
   --connected / --no-connected  True if unconnected voxels are removed, False

--- a/src/cell_abm_pipeline/initial_conditions/__main__.py
+++ b/src/cell_abm_pipeline/initial_conditions/__main__.py
@@ -149,11 +149,11 @@ def sample_images(obj, **kwargs):
     show_default=True,
 )
 @click.option(
-    "--select",
+    "--include",
     type=int,
     multiple=True,
     default=None,
-    help="Specific cell ids to select.",
+    help="Specific cell ids to include.",
     show_default=True,
 )
 @click.option(

--- a/src/cell_abm_pipeline/initial_conditions/__main__.py
+++ b/src/cell_abm_pipeline/initial_conditions/__main__.py
@@ -157,6 +157,14 @@ def sample_images(obj, **kwargs):
     show_default=True,
 )
 @click.option(
+    "--exclude",
+    type=int,
+    multiple=True,
+    default=None,
+    help="Specific cell ids to exclude.",
+    show_default=True,
+)
+@click.option(
     "--edges/--no-edges",
     default=False,
     help="True if cells touching edges are removed, False otherwise.  [default: False]",

--- a/src/cell_abm_pipeline/initial_conditions/process_samples.py
+++ b/src/cell_abm_pipeline/initial_conditions/process_samples.py
@@ -81,7 +81,7 @@ class ProcessSamples:
         self,
         grid: str = "rect",
         scale: Optional[float] = None,
-        select: Optional[List[int]] = None,
+        include: Optional[List[int]] = None,
         edges: bool = False,
         connected: bool = False,
         contact: bool = True,
@@ -95,8 +95,8 @@ class ProcessSamples:
             Type of sampling grid.
         scale
             Coordinate scaling factor.
-        select
-            Specific cell ids to select
+        include
+            Specific cell ids to include.
         edges
             True if cells touching edges are removed, False otherwise.
         connected
@@ -105,7 +105,7 @@ class ProcessSamples:
             True if contact sheet of images is saved, False otherwise.
         """
         for key in self.context.keys:
-            self.process_samples(key, grid, scale, select, edges, connected)
+            self.process_samples(key, grid, scale, include, edges, connected)
 
             if contact:
                 self.plot_contact_sheet(key)
@@ -115,7 +115,7 @@ class ProcessSamples:
         key: str,
         grid: str,
         scale: Optional[float],
-        select: Optional[List[int]],
+        include: Optional[List[int]],
         edges: bool,
         connected: bool,
     ) -> None:
@@ -128,7 +128,7 @@ class ProcessSamples:
         1. Remove unconnected regions (if **connected** is True)
         2. Remove cells at the edge (if **edges** is True)
         3. Rescale sample coordinates (if **scale** is not None)
-        4. Select only samples for given cell ids (if **select** is not None)
+        4. Include only samples for given cell ids (if **include** is not None)
 
         Parameters
         ----------
@@ -138,8 +138,8 @@ class ProcessSamples:
             Type of sampling grid.
         scale
             Coordinate scaling factor.
-        select
-            Specific cell ids to select
+        include
+            Specific cell ids to include.
         edges
             True if cells touching edges are removed, False otherwise.
         connected
@@ -161,9 +161,9 @@ class ProcessSamples:
             print("Scaling coordinates ...")
             processed_samples = self.scale_coordinates(processed_samples, scale)
 
-        if select:
-            print("Selecting cell ids ...")
-            processed_samples = self.select_cells(processed_samples, select)
+        if include:
+            print("Including cell ids ...")
+            processed_samples = self.include_cells(processed_samples, include)
 
         processed_key = make_full_key(self.folders, self.files, "processed", key)
         save_dataframe(self.context.working, processed_key, processed_samples, index=False)
@@ -254,23 +254,23 @@ class ProcessSamples:
         return samples
 
     @staticmethod
-    def select_cells(samples: pd.DataFrame, select: List[int]) -> pd.DataFrame:
+    def include_cells(samples: pd.DataFrame, include: List[int]) -> pd.DataFrame:
         """
-        Filters samples to select for given ids.
+        Filters samples to include given ids.
 
         Parameters
         ----------
         samples
             Sample cell ids and coordinates.
-        select
-            List of ids to select.
+        include
+            List of ids to include.
 
         Returns
         -------
         :
-            Samples from selected ids.
+            Samples from included ids.
         """
-        samples = samples[samples.id.isin(select)]
+        samples = samples[samples.id.isin(include)]
         return samples.reset_index(drop=True)
 
     @staticmethod

--- a/tests/cell_abm_pipeline/initial_conditions/test_process_samples.py
+++ b/tests/cell_abm_pipeline/initial_conditions/test_process_samples.py
@@ -68,18 +68,18 @@ class TestProcessSamples(unittest.TestCase):
         for a, b in zip(z_scaled, scaled_samples["z_scaled"]):
             self.assertAlmostEqual(a, b, places=5)
 
-    def test_select_cells(self):
+    def test_include_cells(self):
         cell_1_data = [[1, 1, 2, 3]]
         cell_2_data = [[2, 1, 2, 1]]
         cell_3_data = [[3, 1, 2, 2]]
         sample_data = cell_1_data + cell_2_data + cell_3_data
         samples = pd.DataFrame(sample_data, columns=["id", "x", "y", "z"])
 
-        select = [2, 3]
+        include = [2, 3]
         expected_data = cell_2_data + cell_3_data
         expected_samples = pd.DataFrame(expected_data, columns=["id", "x", "y", "z"])
 
-        selected_samples = ProcessSamples.select_cells(samples, select)
+        selected_samples = ProcessSamples.include_cells(samples, include)
 
         self.assertTrue(expected_samples.equals(selected_samples))
 

--- a/tests/cell_abm_pipeline/initial_conditions/test_process_samples.py
+++ b/tests/cell_abm_pipeline/initial_conditions/test_process_samples.py
@@ -83,6 +83,21 @@ class TestProcessSamples(unittest.TestCase):
 
         self.assertTrue(expected_samples.equals(selected_samples))
 
+    def test_exclude_cells(self):
+        cell_1_data = [[1, 1, 2, 3]]
+        cell_2_data = [[2, 1, 2, 1]]
+        cell_3_data = [[3, 1, 2, 2]]
+        sample_data = cell_1_data + cell_2_data + cell_3_data
+        samples = pd.DataFrame(sample_data, columns=["id", "x", "y", "z"])
+
+        exclude = [2]
+        expected_data = cell_1_data + cell_3_data
+        expected_samples = pd.DataFrame(expected_data, columns=["id", "x", "y", "z"])
+
+        selected_samples = ProcessSamples.exclude_cells(samples, exclude)
+
+        self.assertTrue(expected_samples.equals(selected_samples))
+
     def test_remove_edge_cells_rect_grid(self):
         edge_threshold = 1
         cell_1_data = [[1, 0, 2, 1], [1, 2, 0, 2], [1, 2, 4, 3], [1, 4, 2, 4]]


### PR DESCRIPTION
Process samples currently has option to include specific cell ids (named `--select`). This PR renames `--select` to `--include` and adds the analogous `--exclude` option for excluding specific cell ids.